### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           fi
 
       - name: Build and publish base container
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: sourcepole/qwc-map-viewer-base
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -27,7 +27,7 @@ jobs:
           tags: "${{ steps.get_tag.outputs.tag }}"
 
       - name: Build and publish demo container
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           QWC2_URL: https://github.com/qgis/qwc2-demo-app/releases/download/ci-latest-master/qwc2-demo-app.zip
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore